### PR TITLE
Dealing with the new device issue after logging in

### DIFF
--- a/lib/amazon_seller_central/mechanizer.rb
+++ b/lib/amazon_seller_central/mechanizer.rb
@@ -3,6 +3,12 @@ module AmazonSellerCentral
   class Mechanizer
     MASQUERADE_AGENTS = ['Mac Safari', 'Mac FireFox', 'Linux Firefox', 'Windows IE 9']
 
+    # constants for the verification page if logged in from a new device
+    VERIF_PAGE_PATTERN      = /What is the ZIP Code/
+    VERIF_PAGE_FORM_NAME    = 'ap_dcq_form'
+    VERIF_PAGE_FIELD_NAME   = 'dcq_question_subjective_1'
+    VERIF_PAGE_ZIP_CODE     = '20706'
+
     attr_reader :agent
 
     def initialize
@@ -51,9 +57,9 @@ module AmazonSellerCentral
         end
 
         # New device verification
-        if p.body =~ /What is the ZIP Code/
-          form = p.form_with(:name => 'ap_dcq_form')
-          form.dcq_question_subjective_1 = '20706'
+        if p.body =~ VERIF_PAGE_PATTERN
+          form = p.form_with(:name => VERIF_PAGE_FORM_NAME)
+          form[VERIF_PAGE_FIELD_NAME] = VERIF_PAGE_ZIP_CODE
           p = form.submit # This raises a response code error, :-(
         end
 


### PR DESCRIPTION
Whenever I saw form that requires the ZIP for verification using mechanizer, I would enter the zip and submit the form. This however always resulted in a Mechanize::ResponseCodeError with this as the first entry of the backtrace:
Mechanize::ResponseCodeError: 500 => Net::HTTPInternalServerError for https://sellercentral.amazon.com/ap/dcq -- unhandled response

Then if I tried to log in again, everything would work just fine. So my patch checks for the verification page, submits the zip and if the expected exception is raised, I log in again. I raise the error if the login fails after the third attempt.
