### PR TITLE
Update of MASQUERADE_AGENTS

### DIFF
--- a/lib/amazon_seller_central/mechanizer.rb
+++ b/lib/amazon_seller_central/mechanizer.rb
@@ -1,7 +1,7 @@
 require 'mechanize'
 module AmazonSellerCentral
   class Mechanizer
-    MASQUERADE_AGENTS = ['Mac Safari', 'Mac FireFox', 'Linux Firefox', 'Windows IE 9']
+    MASQUERADE_AGENTS = ['Mac Safari', 'Mac Firefox', 'Linux Firefox', 'Windows IE 9']
 
     # constants for the verification page if logged in from a new device
     VERIF_PAGE_PATTERN      = /What is the ZIP Code/


### PR DESCRIPTION
Warning that
`Mechanize#user_agent_alias: "Mac FireFox" should be spelled as "Mac Firefox"`

'Mac FireFox' ->
'Mac Firefox'
