### PR TITLE
According to the latest html, it changed the form name & type

### DIFF
--- a/lib/amazon_seller_central/mechanizer.rb
+++ b/lib/amazon_seller_central/mechanizer.rb
@@ -43,7 +43,7 @@ module AmazonSellerCentral
 
         begin
           form['email']    = login_email
-          form['password']    = login_password
+          form['password'] = login_password
           p = form.submit
 
           if p =~ /better protect/ # capcha!

--- a/lib/amazon_seller_central/mechanizer.rb
+++ b/lib/amazon_seller_central/mechanizer.rb
@@ -37,12 +37,12 @@ module AmazonSellerCentral
       begin
         tries -= 1
         page = agent.get('https://sellercentral.amazon.com/gp/homepage.html')
-        form = page.form_with(:name => 'signinWidget')
+        form = page.form_with(:name => 'signIn')
 
         raise FormNotFoundError unless form
 
         begin
-          form['username']    = login_email
+          form['email']    = login_email
           form['password']    = login_password
           p = form.submit
 


### PR DESCRIPTION
HTML of the Amazon SellerCentral login screen has been changed.
Fixed so the login fails.

Since the current test is broken , and commits later fix .
